### PR TITLE
Update Electron Libs Mirror

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aminya/cmake-ts",
-  "version": "0.3.0-aminya.7",
+  "version": "0.4.0-aminya.1",
   "description": "cmake-js rewrite in typescript to support advanced build configurations",
   "main": "build/lib.js",
   "bin": "build/main.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aminya/cmake-ts",
-  "version": "0.4.0-aminya.1",
+  "version": "0.4.1-aminya.1",
   "description": "cmake-js rewrite in typescript to support advanced build configurations",
   "main": "build/lib.js",
   "bin": "build/main.js",

--- a/src/argumentBuilder.ts
+++ b/src/argumentBuilder.ts
@@ -21,11 +21,8 @@ export class ArgumentBuilder {
     baseCommand += ` ${ defines.map(d => `-D${d[0]}="${d[1]}"`).join(" ")}`;
     if (this.options.generatorToUse !== 'native') {
       let generatorString = ` -G"${this.options.generatorToUse}"`;
-      if(
-        generatorString.match(/Visual\s+Studio\s+\d+\s+\d+.*/) &&
-        !generatorString.includes("Win64") &&
-        !generatorString.includes("x86")
-      ) {
+      if(generatorString.match(/Visual\s+Studio\s+\d+\s+\d+\s-A/)) {
+        generatorString = generatorString.replace(/\s-A/, '');
         generatorString += ` -A ${this.config.arch}`;
       }
       baseCommand += generatorString;

--- a/src/argumentBuilder.ts
+++ b/src/argumentBuilder.ts
@@ -20,7 +20,11 @@ export class ArgumentBuilder {
     const defines = await this.buildDefines();
     baseCommand += ` ${ defines.map(d => `-D${d[0]}="${d[1]}"`).join(" ")}`;
     if (this.options.generatorToUse !== 'native') {
-      baseCommand += ` -G"${this.options.generatorToUse}"`;
+      let generatorString = ` -G"${this.options.generatorToUse}"`;
+      if(!generatorString.match(/^Visual\s+Studio\s+\d+\s+\d+(?!.*\s(Win64|x86)$).*/)) {
+        generatorString += ` -A ${this.config.arch}`;
+      }
+      baseCommand += generatorString;
     }
     console.log(baseCommand)
     return baseCommand;

--- a/src/argumentBuilder.ts
+++ b/src/argumentBuilder.ts
@@ -21,7 +21,11 @@ export class ArgumentBuilder {
     baseCommand += ` ${ defines.map(d => `-D${d[0]}="${d[1]}"`).join(" ")}`;
     if (this.options.generatorToUse !== 'native') {
       let generatorString = ` -G"${this.options.generatorToUse}"`;
-      if(!generatorString.match(/^Visual\s+Studio\s+\d+\s+\d+(?!.*\s(Win64|x86)$).*/)) {
+      if(!generatorString.match(
+        /Visual\s+Studio\s+\d+\s+\d+.*/) &&
+        !generatorString.includes("Win64") &&
+        !generatorString.includes("x86")
+      ) {
         generatorString += ` -A ${this.config.arch}`;
       }
       baseCommand += generatorString;

--- a/src/argumentBuilder.ts
+++ b/src/argumentBuilder.ts
@@ -21,8 +21,8 @@ export class ArgumentBuilder {
     baseCommand += ` ${ defines.map(d => `-D${d[0]}="${d[1]}"`).join(" ")}`;
     if (this.options.generatorToUse !== 'native') {
       let generatorString = ` -G"${this.options.generatorToUse}"`;
-      if(!generatorString.match(
-        /Visual\s+Studio\s+\d+\s+\d+.*/) &&
+      if(
+        generatorString.match(/Visual\s+Studio\s+\d+\s+\d+.*/) &&
         !generatorString.includes("Win64") &&
         !generatorString.includes("x86")
       ) {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -212,7 +212,7 @@ export async function defaultBuildOptions(configs: BuildOptions, buildmode: Buil
   let ninja: string | null;
   let make: string | null;
   if (configs.generatorToUse === undefined) {
-    console.log('no generator specified, checking ninja');
+    console.log('no generator specified in package.json, checking ninja');
     ninja = await ninjaP;
     if (!ninja) {
       console.log('ninja not found, checking make');

--- a/src/urlRegistry.ts
+++ b/src/urlRegistry.ts
@@ -5,7 +5,7 @@ import os from 'os';
 
 const NODE_MIRROR = process.env.NVM_NODEJS_ORG_MIRROR || "https://nodejs.org/dist";
 const IOJS_MIRROR = process.env.NVM_IOJS_ORG_MIRROR || "https://iojs.org/dist";
-const ELECTRON_MIRROR = process.env.ELECTRON_MIRROR || "https://atom.io/download/atom-shell";
+const ELECTRON_MIRROR = process.env.ELECTRON_MIRROR || "https://artifacts.electronjs.org/headers/dist";
 
 export const HOME_DIRECTORY = process.env[(os.platform() === "win32") ? "USERPROFILE" : "HOME"] as string;
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -19,23 +19,27 @@ export const GET_CMAKE_VS_GENERATOR = async (cmake: string, arch: string): Promi
       // Some descriptions are multi-line
       continue;
     }
-    genParts[0] = genParts[0].trim();
+    genParts[0] = genParts[0].replace(/^(\* )/, "").trim();
 
     // eslint-disable-next-line optimize-regex/optimize-regex
-    if (genParts[0].match(/Visual\s+Studio\s+\d+\s+\d+\s+\[arch\]/)) {
+    if (genParts[0].match(/Visual\s+Studio\s+\d+\s+\d+(\s+\[arch\])?/)) {
       console.log('Found generator: ', genParts[0]);
       // The first entry is usually the latest entry
       useVSGen = genParts[0];
       break;
     }
   }
-  if (arch === 'x64') {
-    useVSGen = useVSGen.replace('[arch]', 'Win64').trim();
-  } else if (arch === 'x86') {
-    useVSGen = useVSGen.replace('[arch]', '').trim();
-  } else {
-    console.error('Failed to find valid VS gen, using native. Good Luck.');
-    return 'native';
+
+  const useSwitch = !useVSGen.match(/.*\[arch\]/);
+  if(!useSwitch) {
+    if (arch === 'x64') {
+      useVSGen = useVSGen.replace('[arch]', 'Win64').trim();
+    } else if (arch === 'x86') {
+      useVSGen = useVSGen.replace('[arch]', '').trim();
+    } else {
+      console.error('Failed to find valid VS gen, using native. Good Luck.');
+      return 'native';
+    }
   }
   return useVSGen;
 }


### PR DESCRIPTION
Previous CDN used by `cmake-ts` for getting libs for compiling Electron builds was deleted: https://www.electronjs.org/blog/s3-bucket-change

This PR updates `urlRegistry.ts` to use the new one.

Ideally should be merged AFTER https://github.com/aminya/cmake-ts/pull/2 since it branches off of it